### PR TITLE
EI_TOOL-93: Add Service EPR Field for SOAP Tasks

### DIFF
--- a/plugins/org.wso2.developerstudio.bpmn.extensions/src/main/java/org/wso2/developerstudio/bpmn/extensions/restTask/RESTConstants.java
+++ b/plugins/org.wso2.developerstudio.bpmn.extensions/src/main/java/org/wso2/developerstudio/bpmn/extensions/restTask/RESTConstants.java
@@ -52,8 +52,8 @@ public interface RESTConstants {
     public static final String EPR_HELP_LONG =
             "This parameter can be used to point to a registry location which contains an endpoint reference as " +
                     "mentioned in" +
-                    " <a href=\"https://docs.wso2.com/display/BPS350/Endpoint+References\" >https://docs.wso2" +
-                    ".com/display/BPS350/Endpoint+References</a> " +
+                    " <a href=\"https://docs.wso2.com/display/EI620/Endpoint+References\" >https://docs.wso2" +
+                    ".com/display/EI620/Endpoint+References</a> " +
                     "URLs given in such registry resources can be changed after deployment and the current value of " +
                     "the registry resource will be read before each service invocation.  " +
                     "Supports expressions. When Both Service URL and Service Reference (EPR) are defined, only " +

--- a/plugins/org.wso2.developerstudio.bpmn.extensions/src/main/java/org/wso2/developerstudio/bpmn/extensions/soapTask/SOAPConstants.java
+++ b/plugins/org.wso2.developerstudio.bpmn.extensions/src/main/java/org/wso2/developerstudio/bpmn/extensions/soapTask/SOAPConstants.java
@@ -38,6 +38,17 @@ public interface SOAPConstants {
                     "deployment. Supports expressions and string values.\n" +
                     "\n\n \r Eg : http://10.100.4.192:9763/services/HelloService";
 
+    public static final String EPR_LABEL = "Service Reference (EPR)";
+    public static final String EPR_HELP = "Service Reference (EPR)";
+    public static final String EPR_HELP_LONG =
+            "This parameter can be used to point to a registry location which contains an endpoint reference as " +
+                    "mentioned in" +
+                    " <a href=\"https://docs.wso2.com/display/EI620/Endpoint+References\" >https://docs.wso2" +
+                    ".com/display/EI620/Endpoint+References</a> " +
+                    "URLs given in such registry resources can be changed after deployment and the current value of " +
+                    "the registry resource will be read before each service invocation.  " +
+                    "Supports expressions. When Both Service URL and Service Reference (EPR) are defined, only " +
+                    "Service URL will be used. <br/>Eg: conf:/epr/echoService.epr";
 
     public static final String INPUT_LABEL = "Input Payload";
     public static final String INPUT_HELP = "Input Payload";

--- a/plugins/org.wso2.developerstudio.bpmn.extensions/src/main/java/org/wso2/developerstudio/bpmn/extensions/soapTask/SOAPTask.java
+++ b/plugins/org.wso2.developerstudio.bpmn.extensions/src/main/java/org/wso2/developerstudio/bpmn/extensions/soapTask/SOAPTask.java
@@ -54,6 +54,13 @@ public class SOAPTask extends AbstractCustomServiceTask {
     private String serviceURL;
 
     /**
+     * @See SOAPConstants.EPR_HELP_LONG
+     */
+    @Property(type = PropertyType.TEXT, displayName = SOAPConstants.EPR_LABEL, required = false)
+    @Help(displayHelpShort = SOAPConstants.EPR_HELP, displayHelpLong = SOAPConstants.EPR_HELP_LONG)
+    private String serviceRef;
+
+    /**
      * @See SOAPConstants.INPUT_HELP_LONG
      */
     @Property(type = PropertyType.MULTILINE_TEXT, displayName = SOAPConstants.INPUT_LABEL, required = true)


### PR DESCRIPTION
## Purpose
Adding Service reference field for SOAP task.
Resolves https://github.com/wso2/devstudio-tooling-ei/issues/93

## Goals
Introduced "Service Reference" parameter for the property list of SOAP task.

## Approach
![soaptask](https://user-images.githubusercontent.com/5234623/31266042-8ca6d218-aa8f-11e7-8810-186090d5a1fd.png)

## Release note
Fixed https://github.com/wso2/devstudio-tooling-ei/issues/93

## Documentation
https://docs.wso2.com/display/EI620/Invoking+a+BPMN+SOAP+Endpoint
https://docs.wso2.com/display/EI620/Endpoint+References

## Related PRs
https://github.com/wso2/carbon-business-process/commit/7b6f16fd6401a17132281a54af7f4ff410057dca

## Test environment
JDK 8
 