### PR TITLE
Disable required option for Service URL in SOAP task

### DIFF
--- a/plugins/org.wso2.developerstudio.bpmn.extensions/src/main/java/org/wso2/developerstudio/bpmn/extensions/soapTask/SOAPTask.java
+++ b/plugins/org.wso2.developerstudio.bpmn.extensions/src/main/java/org/wso2/developerstudio/bpmn/extensions/soapTask/SOAPTask.java
@@ -49,7 +49,7 @@ public class SOAPTask extends AbstractCustomServiceTask {
     /**
      * @See SOAPConstants.SERVICE_URL_HELP_LONG
      */
-    @Property(type = PropertyType.TEXT, displayName = SOAPConstants.SERVICE_URL_LABEL, required = true)
+    @Property(type = PropertyType.TEXT, displayName = SOAPConstants.SERVICE_URL_LABEL, required = false)
     @Help(displayHelpShort = SOAPConstants.SERVICE_URL_HELP, displayHelpLong = SOAPConstants.SERVICE_URL_HELP_LONG)
     private String serviceURL;
 


### PR DESCRIPTION
## Purpose
With the fix given for https://github.com/wso2/devstudio-tooling-bps/pull/33, SOAP task requires a Service URL or a Service Reference. Therefore, disabling the required option for Service URL.

## Documentation
https://docs.wso2.com/display/EI620/Invoking+a+BPMN+SOAP+Endpoint

## Related PRs
https://github.com/wso2/devstudio-tooling-bps/pull/33

## Test environment
JDK 8
